### PR TITLE
fix: regex for stackoverflow and stackexchange

### DIFF
--- a/firefox-src/background.js
+++ b/firefox-src/background.js
@@ -826,13 +826,13 @@ function updateRules(parameterRedirectServices, customInstances) {
   }
   if (parameterRedirectServices.stackoverflow) {
     redirectRules.push(
-      createRedirectRule(41, "stackoverflow.com", randstackoverflowInstance)
+      createRedirectRule(41, "https?:\/{2}(?:([a-zA-Z0-9-]+)\.)?stackoverflow\.com\/questions", randstackoverflowInstance)
     );
     redirectRules.push({
       id: 42,
       priority: 1,
       condition: {
-        regexFilter: "^https://(.*)\\.stackexchange\\.com/questions/(.*)$",
+        regexFilter: "https?:\/{2}(?:([a-zA-Z0-9-]+)\.)?stackexchange\.com\/questions",
         resourceTypes: ["main_frame"],
       },
       action: {

--- a/src/background.js
+++ b/src/background.js
@@ -827,13 +827,13 @@ function updateRules(parameterRedirectServices, customInstances) {
   }
   if (parameterRedirectServices.stackoverflow) {
     redirectRules.push(
-      createRedirectRule(41, "stackoverflow.com", randstackoverflowInstance)
+      createRedirectRule(41, "https?:\/{2}(?:([a-zA-Z0-9-]+)\.)?stackoverflow\.com\/questions", randstackoverflowInstance)
     );
     redirectRules.push({
       id: 42,
       priority: 1,
       condition: {
-        regexFilter: "^https://(.*)\\.stackexchange\\.com/questions/(.*)$",
+        regexFilter: "https?:\/{2}(?:([a-zA-Z0-9-]+)\.)?stackexchange\.com\/questions",
         resourceTypes: ["main_frame"],
       },
       action: {


### PR DESCRIPTION
Thanks for creating this extension. It seems to work mostly fine except for the stackoverflow/exchange redirection. I noticed that libredirect uses more complex regex to match it, perhaps this would fix the issue. I don't know how to test this.