### PR TITLE
Remove Esmail Elbob instances

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -92,7 +92,6 @@ const twitterInstances = [
   "nitter.adminforge.de",
   "nitter.catsarch.com",
   "nitter.cz",
-  "nitter.esmailelbob.xyz",
   "nitter.eu.projectsegfau.lt",
   "nitter.in.projectsegfau.lt",
   "nitter.io.lol",
@@ -134,7 +133,6 @@ const tiktokInstances = [
 const quoraInstances = [
   "quetre.iket.me",
   "quetre.pussthecat.org",
-  "quetre.esmailelbob.xyz",
   "quetre.privacydev.net",
   "quetre.blackdrgn.nl",
   "quetre.lunar.icu",
@@ -159,7 +157,6 @@ const fandomInstances = [
 ];
 const imdbInstances = [
   "libremdb.pussthecat.org",
-  "libremdb.esmailelbob.xyz",
   "libremdb.iket.me",
   "ld.vern.cc",
   "binge.whatever.social",
@@ -172,14 +169,12 @@ const geniusInstances = [
   "dm.vern.cc",
   "sing.whatever.social",
   "dumb.lunar.icu",
-  "dumb.esmailelbob.xyz",
 ];
 const ytmusicInstances = [
   "beatbump.io",
   "bb.vern.cc",
   "bb.ggtyler.dev",
   "hyperpipe.surge.sh",
-  "hyperpipe.esmailelbob.xyz",
   "listen.whatever.social",
   "music.adminforge.de",
   "music.pfcd.me",
@@ -296,9 +291,8 @@ const soundcloudInstances = ["tubo.migalmoreno.com"];
 const udInstances = [
   "rd.vern.cc",
   "rd.bloat.cat",
-  "ruraldictionary.esmailelbob.xyz",
 ];
-const instructablesInstances = ["ds.vern.cc", "destructables.esmailelbob.xyz"];
+const instructablesInstances = ["ds.vern.cc"];
 const knowyourmemeInstances = ["mm.vern.cc"];
 const searchInstances = [
   "search.bus-hit.me",
@@ -317,7 +311,7 @@ const translateInstances = [
   "translate.bus-hit.me",
   "nyc1.mz.ggtyler.dev",
 ];
-const snopesInstances = ["sd.vern.cc", "suds.esmailelbob.xyz"];
+const snopesInstances = ["sd.vern.cc"];
 const reutersInstances = ["neuters.de"];
 const stackoverflowInstances = [
   "code.whatever.social",


### PR DESCRIPTION
Esmail Elbob discriminates against gay/queer/LGBTQ+ users and forbids them to use his instances via a Terms Of Service document.

This is discriminatory, unfair, and disrespectful towards people who wish to use his instances, as well as the people creating alternative frontends. Multiple authors of alternative frontends are LGBTQ+.

LGBTQ+ Predirect users might be automatically redirected to his instance, but he does not allow this. Since Predirect does not know the identity of its users, Predirect should stop redirecting anybody to his instances, just in case.

This pull request removes his instances.

## Further context

The following projects have removed his instances from their official lists:

- [Invidious](https://github.com/iv-org/documentation/issues/395)
- [BreezeWiki](https://lists.sr.ht/~cadence/breezewiki-discuss/%3C96635f17-3bc3-7085-dcb6-9552f927ae8c@magiclike.net%3E)
- [Piped](https://github.com/TeamPiped/Piped/issues/2435)
- [rimgo](https://codeberg.org/rimgo/rimgo/issues/106)
- [Whoogle](https://github.com/benbusby/whoogle-search/issues/1006)
- [Scribe](https://todo.sr.ht/~edwardloveall/Scribe/27)
- [AnonymousOverflow](https://github.com/httpjamesm/AnonymousOverflow/issues/34)

The following projects have chosen to leave them:

- [HyperPipe](https://codeberg.org/Hyperpipe/pages/issues/13)
- [nitter](https://github.com/zedeus/nitter/issues/883)
- [Rural Dictionary](https://codeberg.org/zortazert/rural-dictionary/issues/14)