### PR TITLE
Add optional full URL handling for custom instances

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -413,6 +413,17 @@ function updateRules(parameterRedirectServices, customInstances) {
     getRandomInstance(stackoverflowInstances);
 
   function createRedirectRule(id, filter, instance) {
+    try {
+      uri = new URL(instance)
+      protocol = uri.protocol.slice(0, -1) //uri.protocol returns a trailing colon; slice that off
+      instance = uri.hostname
+      port = uri.port
+    } catch {
+      protocol = "https"
+      port = null
+    }
+    var transform = { scheme: protocol, host: instance, port: port }
+
     return {
       id: id,
       priority: 1,
@@ -424,7 +435,7 @@ function updateRules(parameterRedirectServices, customInstances) {
       action: {
         type: "redirect",
         redirect: {
-          transform: { scheme: "https", host: instance },
+          transform: transform,
         },
       },
     };


### PR DESCRIPTION
This PR adds some additional parsing logic to allow custom instance fields to be full URLs.

The primary benefit from the additional parsing is that custom instances can specify properties they couldn't before - specifically, port numbers and plain HTTP, if desired. This is particularly handy for users self-hosting their own frontends.

If the custom instance field is not populated with a valid URL, the extension will fall back to the old behavior - in other words, it should be fully backwards compatible.

cc: @libreom 